### PR TITLE
Benchmarks around filling lists

### DIFF
--- a/microbenchmarks/lists/all.sh
+++ b/microbenchmarks/lists/all.sh
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+echo Dart
+dart test.dart
+echo
+
+echo C
+clang -Ofast test.c && ./a.out
+echo
+
+echo Kotlin/Native
+kotlinc-native -opt test.kt && ./program.kexe
+echo
+
+echo Kotlin on JVM
+kotlinc-jvm test.kt -include-runtime -d test.jar && java -jar test.jar
+echo
+
+echo FPC
+fpc -O4 -v0 test.pas && ./test
+echo
+
+echo Perl
+perl test.pl
+echo
+
+echo Generating JavaScript from Dart and Kotlin
+dart2js test.dart -o out.dart.js -O4
+kotlinc-js test.kt -output out.kotlin.js

--- a/microbenchmarks/lists/test.c
+++ b/microbenchmarks/lists/test.c
@@ -1,0 +1,19 @@
+// Copyright 2020 Google LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <time.h>
+#include <stdio.h>
+
+const int size = 100000;
+int main() {
+  clock_t watch = clock();
+  int index = 0;
+  while (index < 10000) {
+    int foo[size];
+    for (int subindex = 0; subindex < size; subindex += 1)
+      foo[subindex] = 1;
+    index += foo[12487];
+  }
+  printf("%.2fs\n", (double)(clock() - watch) / 1000000);
+}

--- a/microbenchmarks/lists/test.dart
+++ b/microbenchmarks/lists/test.dart
@@ -1,0 +1,14 @@
+// Copyright 2020 Google LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+const size = 100000;
+void main() {
+  final Stopwatch watch = Stopwatch()..start();
+  int index = 0;
+  while (index < 10000) {
+    final List<int> foo = List.filled(size, 1);
+    index += foo[12487];
+  }
+  print('${(watch.elapsedMicroseconds / 1000000).toStringAsFixed(2)}s');
+}

--- a/microbenchmarks/lists/test.kt
+++ b/microbenchmarks/lists/test.kt
@@ -1,0 +1,19 @@
+// Copyright 2020 Google LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import kotlin.time.*
+
+const val size = 100000
+
+@kotlin.time.ExperimentalTime
+fun main() {
+  val watch: Duration = measureTime {
+    var index: Int = 0
+    while (index < 10000) {
+      val foo: List<Int> = List(size) { 1 }
+      index += foo[12487]
+    }
+  }
+  println("${watch.inSeconds}s")
+}

--- a/microbenchmarks/lists/test.pas
+++ b/microbenchmarks/lists/test.pas
@@ -1,0 +1,24 @@
+// Copyright 2020 Google LLC. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+{$MODE OBJFPC}
+uses SysUtils, DateUtils;
+
+const
+   Size = 100000;
+var
+   Watch: TDateTime;
+   Index, Subindex: Integer;
+   Foo: array[0..Size-1] of Integer;
+begin
+   Watch := Now;
+   Index := 0;
+   while (Index < 10000) do
+   begin
+      for Subindex := 0 to Size - 1 do
+         Foo[Subindex] := 1;
+      Index += Foo[12487];
+   end;
+   WriteLn(Format('%.2fs', [(Now - Watch) * 24 * 60 * 60]));
+end.

--- a/microbenchmarks/lists/test.pl
+++ b/microbenchmarks/lists/test.pl
@@ -1,0 +1,17 @@
+# Copyright 2020 Google LLC. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+use strict;
+use warnings;
+use Time::HiRes;
+
+use constant size => 100000;
+
+my $watch = Time::HiRes::gettimeofday();
+my $index = 0;
+while ($index < 10000) {
+  my @foo = (1) x size;
+  $index += $foo[12487];
+}
+printf("%.2fs\n", (Time::HiRes::gettimeofday() - $watch));


### PR DESCRIPTION
On my local machine (iMac Pro) I get:

Dart   12.21s
C       0.05s
Kotlin 24.85s
FPC     1.83s
Perl   24.93s

(Nothing special about those languages in particular, just happened to be what I had at hand. Also I suspect, but haven't checked, that the C compiler is basically optimising the benchmark away.)